### PR TITLE
Update vsixmanifest for VS2019 support

### DIFF
--- a/src/WinService.VSIX/source.extension.vsixmanifest
+++ b/src/WinService.VSIX/source.extension.vsixmanifest
@@ -23,6 +23,6 @@
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="Windows Service Plus" d:TargetPath="|WinService.Template;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Microsoft.VisualStudio.Component.CoreEditor prerequisite should have an open-ended upper bound for VS2019 support according to:
https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/

Fixes this error:
The extension with ID 'WinService.VSIX.Emerson Brito.390f72bc-9d4e-4cf2-b0bc-382013f6977c' is not installed to Microsoft Visual Studio Community 2019.
Extension cannot be installed to the following products due to missing prerequisites:
Microsoft Visual Studio Community 2019
		-------------------------------------------------------
		Identifier   : Microsoft.VisualStudio.Component.CoreEditor
		Name         : Visual Studio core editor
		Version      : [15.8.27729.1,16.0)
		Error        : The prerequisite version specified does not match the version installed